### PR TITLE
Look up fields and props only once

### DIFF
--- a/netcore-ef-util/Either.cs
+++ b/netcore-ef-util/Either.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace SearchAThing.Helpers
+{
+    // thank you to https://stackoverflow.com/a/3199453/1586229
+    public abstract class Either<L, R>
+    {
+        public abstract T Match<T>(Func<L, T> f, Func<R, T> g);
+        public abstract void Match(Action<L> f, Action<R> g);
+
+        public abstract Either<T, R> Map<T>(Func<L, T> f);
+
+        // private ctor ensures no external classes can inherit
+        // (not sure why that's important, but it's in the SO answer)
+        private Either() { }
+        public sealed class Left : Either<L, R>
+        {
+            public readonly L Item;
+            public Left(L item) : base() { this.Item = item; }
+            public override T Match<T>(Func<L, T> f, Func<R, T> g)
+            {
+                return f(Item);
+            }
+            public override void Match(Action<L> f, Action<R> g)
+            {
+                f(Item);
+            }
+            public override Either<T, R> Map<T>(Func<L, T> f)
+            {
+                return f(Item);
+            }
+        }
+        public static implicit operator Either<L, R>(L ell)
+        {
+            return new Left(ell);
+        }
+
+        public sealed class Right : Either<L, R>
+        {
+            public readonly R Item;
+            public Right(R item) { this.Item = item; }
+            public override T Match<T>(Func<L, T> f, Func<R, T> g)
+            {
+                return g(Item);
+            }
+            public override void Match(Action<L> f, Action<R> g)
+            {
+                g(Item);
+            }
+            public override Either<T, R> Map<T>(Func<L, T> f)
+            {
+                return Item;
+            }
+
+
+        }
+        public static implicit operator Either<L, R>(R arr)
+        {
+            return new Right(arr);
+        }
+    }
+
+}

--- a/netcore-ef-util/Mapper.cs
+++ b/netcore-ef-util/Mapper.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection;
+using SearchAThing.Helpers;
+
+namespace SearchAThing.Mapper
+{
+    // danke schoen https://codereview.stackexchange.com/a/98736
+    public class DataReaderMapper<T>
+    {
+        Dictionary<int, Either<FieldInfo, PropertyInfo>> mappings;
+        bool IsPrimitiveish;
+        public DataReaderMapper(IDataReader reader)
+        {
+            Type U = Nullable.GetUnderlyingType(typeof(T));
+            this.IsPrimitiveish = (
+                typeof(T).IsPrimitive ||
+                (U != null && U.IsPrimitive)
+            );
+            if (!this.IsPrimitiveish)
+            {
+                this.mappings = Mappings(reader);
+            }
+        }
+
+        public class MapMismatchException : Exception
+        {
+            public MapMismatchException(string arg) : base(arg) { }
+        }
+
+        private class JoinInfo
+        {
+            public Either<FieldInfo, PropertyInfo> info;
+            public String name;
+        }
+        // int keys are column indices (ordinals)
+        static Dictionary<int, Either<FieldInfo, PropertyInfo>> Mappings(IDataReader reader)
+        {
+            var columns = Enumerable.Range(0, reader.FieldCount);
+            var fieldsAndProps = typeof(T).FieldsAndProps()
+                .Select(fp => fp.Match(
+                    f => new JoinInfo { info = f, name = f.Name },
+                    p => new JoinInfo { info = p, name = p.Name }
+                ));
+            var joined = columns
+                  .Join(fieldsAndProps, reader.GetName, x => x.name, (index, x) => new
+                  {
+                      index,
+                      x.info
+                  }, StringComparer.InvariantCultureIgnoreCase).ToList();
+            if (columns.Count() != joined.Count() || fieldsAndProps.Count() != joined.Count())
+            {
+                throw new MapMismatchException($"Expected to map every column in the result. " +
+                    $"Instead, {columns.Count()} columns and {fieldsAndProps.Count()} fields produced only {joined.Count()} matches. " +
+                    $"Hint: be sure all your columns have _names_, and the names match up.");
+            }
+            return joined
+                 .ToDictionary(x => x.index, x => x.info);
+        }
+
+        public T MapFrom(IDataRecord record)
+        {
+            if (IsPrimitiveish)
+            {
+                // Primitive values will always have a single column, indexed by 0
+                return (T)record.GetValue(0);
+            }
+            var element = Activator.CreateInstance<T>();
+            foreach (var map in mappings)
+                map.Value.Match(
+                    f => f.SetValue(element, ChangeType(record[map.Key], f.FieldType)),
+                    p => p.SetValue(element, ChangeType(record[map.Key], p.PropertyType))
+                );
+
+            return element;
+        }
+
+        static object ChangeType(object value, Type targetType)
+        {
+            if (value == null || value == DBNull.Value)
+                return null;
+
+            return Convert.ChangeType(value, Nullable.GetUnderlyingType(targetType) ?? targetType);
+        }
+    }
+
+    public static class FieldAndPropsExtension
+    {
+        public static IEnumerable<Either<FieldInfo, PropertyInfo>> FieldsAndProps(this Type T)
+        {
+            var lst = new List<Either<FieldInfo, PropertyInfo>>();
+            lst.AddRange(
+                T.GetFields()
+                .Select(field => new Either<FieldInfo, PropertyInfo>.Left(field))
+            );
+            lst.AddRange(
+                T.GetProperties()
+                .Select(prop => new Either<FieldInfo, PropertyInfo>.Right(prop))
+            );
+            return lst;
+        }
+    }
+
+
+}


### PR DESCRIPTION
prior to this commit, fields and props were evaluated once for every
row returned. With this change, the info is cached for a given query